### PR TITLE
Set region from GQL settings

### DIFF
--- a/pkg/aws/awsclient.go
+++ b/pkg/aws/awsclient.go
@@ -78,9 +78,14 @@ func newAwsClientConfig() *awsClientConfig {
 func NewClient(ctx context.Context, creds *Credentials) (*awsClient, error) {
 	awsCfg := newAwsClientConfig()
 
+	region := awsCfg.Region
+	if region == "" {
+		region = creds.DefaultRegion
+	}
+
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
-		config.WithRegion(awsCfg.Region),
+		config.WithRegion(region),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, "")))
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating AWS configuration")

--- a/pkg/aws/credentials.go
+++ b/pkg/aws/credentials.go
@@ -12,13 +12,15 @@ import (
 type Credentials struct {
 	AccessKeyID     string
 	SecretAccessKey string
+	DefaultRegion   string
 }
 
 func getCredentialsFromEnv() *Credentials {
-	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" && os.Getenv("AWS_REGION") != "" {
 		return &Credentials{
 			AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
 			SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			DefaultRegion:   os.Getenv("AWS_REGION"),
 		}
 	}
 	return nil
@@ -41,6 +43,7 @@ func getCredentialsFromVault(ctx context.Context, vc *vault.VaultClient, account
 	return &Credentials{
 		AccessKeyID:     aws_access_key_id,
 		SecretAccessKey: aws_secret_access_key,
+		DefaultRegion:   accounts[0].GetResourcesDefaultRegion(),
 	}, nil
 
 }

--- a/pkg/aws/credentials_test.go
+++ b/pkg/aws/credentials_test.go
@@ -18,11 +18,13 @@ func TestGetCredentialsFromEnv(t *testing.T) {
 	assert.Nil(t, getCredentialsFromEnv())
 
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "bar")
+	t.Setenv("AWS_REGION", "us-east-1")
 	c := getCredentialsFromEnv()
 	assert.NotNil(t, c)
 	assert.IsType(t, &Credentials{}, c)
 	assert.Equal(t, "foo", c.AccessKeyID)
 	assert.Equal(t, "bar", c.SecretAccessKey)
+	assert.Equal(t, "us-east-1", c.DefaultRegion)
 }
 
 func setupVaultMock(t *testing.T) *httptest.Server {
@@ -45,7 +47,10 @@ func TestGetCredentialsFromVault(t *testing.T) {
 
 	accounts := getAccountsResponse{
 		[]getAccountsAwsaccounts_v1AWSAccount_v1{
-			{AutomationToken: getAccountsAwsaccounts_v1AWSAccount_v1AutomationTokenVaultSecret_v1{Path: "token"}},
+			{
+				AutomationToken:        getAccountsAwsaccounts_v1AWSAccount_v1AutomationTokenVaultSecret_v1{Path: "token"},
+				ResourcesDefaultRegion: "us-east-1",
+			},
 		},
 	}
 
@@ -61,6 +66,7 @@ func TestGetCredentialsFromVault(t *testing.T) {
 
 	assert.Equal(t, "foo", c.AccessKeyID)
 	assert.Equal(t, "bar", c.SecretAccessKey)
+	assert.Equal(t, "us-east-1", c.DefaultRegion)
 }
 
 func TestGuessAccountName(t *testing.T) {


### PR DESCRIPTION
Setting the region from GQL settings, AWS_REGION is not set everywhere and is supposed to be read from GQL if applicable