### PR TITLE
APPSRE-7122: Use streaming I/O with Age when encrypting the archive

### DIFF
--- a/internal/gitpartitionsync/producer/encrypt.go
+++ b/internal/gitpartitionsync/producer/encrypt.go
@@ -2,6 +2,7 @@ package producer
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -30,7 +31,7 @@ func (g *GitPartitionSyncProducer) encryptRepoTars(tarPath string, sync syncConf
 	defer f.Close()
 
 	// read in tar data
-	tarBytes, err := os.ReadFile(tarPath)
+	tarFile, err := os.Open(tarPath)
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +41,10 @@ func (g *GitPartitionSyncProducer) encryptRepoTars(tarPath string, sync syncConf
 	if err != nil {
 		return "", err
 	}
-	encWriter.Write(tarBytes)
+
+	if _, err := io.Copy(encWriter, tarFile); err != nil {
+		return "", err
+	}
 
 	if err := encWriter.Close(); err != nil {
 		return "", err

--- a/internal/gitpartitionsync/producer/encrypt.go
+++ b/internal/gitpartitionsync/producer/encrypt.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	"filippo.io/age"
 )
@@ -24,14 +25,14 @@ func (g *GitPartitionSyncProducer) encryptRepoTars(tarPath string, sync syncConf
 	}
 
 	encryptPath := fmt.Sprintf("%s/%s/%s.tar.age", g.config.Workdir, ENCRYPT_DIRECTORY, sync.SourceProjectName)
-	f, err := os.Create(encryptPath)
+	f, err := os.Create(filepath.Clean(encryptPath))
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
 
 	// read in tar data
-	tarFile, err := os.Open(tarPath)
+	tarFile, err := os.Open(filepath.Clean(tarPath))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Currently, within the Git Partition Sync: Producer service, the content of the Tar archive to be encrypted with Age is read entirely into the memory to be passed as a buffer of bytes to the encryption routine. Depending on the archive file size, this can lead to an increase in memory usage. 

Since multiple archive files are processed during the service lifetime, this can lead to high memory and eventually to memory limit exhaustion. The garbage collection mechanism might need to act faster to release leftover buffers. This will lead to the service being terminated with an OOM error, as it would have exhausted its allotted memory allocation limits.

Thus, move to streaming I/O with Age rather than reading the entire file content into a memory buffer, reducing the service's memory footprint.

Related: [APPSRE-7122](https://issues.redhat.com/browse/APPSRE-7122)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>