### PR TITLE
APPSRE-7136: Ensure Close() is always called to avoid file descriptor leak on error

### DIFF
--- a/internal/gitpartitionsync/producer/tar.go
+++ b/internal/gitpartitionsync/producer/tar.go
@@ -74,9 +74,9 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 			return err
 		}
 
-		// manually close here after each file operation; defering would cause each file close
-		// to wait until all operations have completed.
-		f.Close()
+		if err := f.Close(); err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/internal/gitpartitionsync/producer/tar.go
+++ b/internal/gitpartitionsync/producer/tar.go
@@ -65,6 +65,9 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 		if err != nil {
 			return err
 		}
+		// Closing a healthy file twice yields a syscall.EINVAL
+		// error which is safe to discard in this case.
+		defer func() { _ = f.Close() }()
 
 		// copy file data into tar writer
 		if _, err := io.Copy(tw, f); err != nil {

--- a/internal/gitpartitionsync/producer/tar.go
+++ b/internal/gitpartitionsync/producer/tar.go
@@ -36,7 +36,6 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 	tw := tar.NewWriter(gzw)
 	defer tw.Close()
 
-	// credit: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07
 	err = filepath.Walk(repoPath, func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/internal/gitpartitionsync/producer/tar.go
+++ b/internal/gitpartitionsync/producer/tar.go
@@ -66,7 +66,7 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 		}
 		// Closing a healthy file twice yields a syscall.EINVAL
 		// error which is safe to discard in this case.
-		defer func() { _ = f.Close() }()
+		defer f.Close()
 
 		// copy file data into tar writer
 		if _, err := io.Copy(tw, f); err != nil {

--- a/internal/gitpartitionsync/producer/tar.go
+++ b/internal/gitpartitionsync/producer/tar.go
@@ -24,7 +24,7 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 	}
 
 	tarPath := fmt.Sprintf("%s/%s/%s.tar", g.config.Workdir, TAR_DIRECTORY, sync.SourceProjectName)
-	f, err := os.Create(tarPath)
+	f, err := os.Create(filepath.Clean(tarPath))
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +60,7 @@ func (g *GitPartitionSyncProducer) tarRepos(repoPath string, sync syncConfig) (s
 		}
 
 		// open files for taring
-		f, err := os.Open(file)
+		f, err := os.Open(filepath.Clean(file))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, a subtle bug manifests itself within the Git Partition Sync: Producer service. The open file descriptor will not be closed when an error occurs. This inadvertently leaks an open file descriptor for the lifetime of the running process.

Thus, even though this only happens on the failure path, this still needs to be fixed. 

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>