### PR TITLE
Remove PGP key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ vault:
 
 user_validator:
   concurrency: Number of coroutines to use to query Github (default: 10)
-  invalidusers: Comma seperated list of keys know to be invalid and skipd for PGP key validation
 
 github:
   timeout: Timeout in seconds for Github request (default: 60s)
@@ -82,7 +81,6 @@ Instead of using a yaml file, all parameters can be set via environment variable
  * VAULT_SECRET_ID
  * VAULT_TIMEOUT
  * USER_VALIDATOR_CONCURRENCY
- * USER_VALIDATOR_INVALID_USERS
  * UNLEASH_TIMEOUT
  * UNLEASH_API_URL
  * UNLEASH_CLIENT_ACCESS_TOKEN

--- a/internal/uservalidator/user_validator_test.go
+++ b/internal/uservalidator/user_validator_test.go
@@ -27,35 +27,6 @@ func readKeyFile(t *testing.T, fileName string) []byte {
 	return key
 }
 
-func TestValidatePgpKeysValid(t *testing.T) {
-	v := ValidateUser{}
-	v.ValidateUserConfig = &ValidateUserConfig{}
-	userResponse := UsersResponse{
-		Users_v1: []UsersUsers_v1User_v1{{
-			Public_gpg_key: string(readKeyFile(t, publicFile)),
-		}},
-	}
-	validationErrors := v.validatePgpKeys(userResponse)
-	assert.Len(t, validationErrors, 0)
-}
-
-func TestValidatePgpKeysInValid(t *testing.T) {
-	// Todo add fixture for expired key
-	v := ValidateUser{}
-	v.ValidateUserConfig = &ValidateUserConfig{}
-	userResponse := UsersResponse{
-		Users_v1: []UsersUsers_v1User_v1{{
-			Path:           "/foo/bar",
-			Public_gpg_key: "a",
-		}},
-	}
-	validationErrors := v.validatePgpKeys(userResponse)
-	assert.Len(t, validationErrors, 1)
-	assert.Equal(t, "validatePgpKeys", validationErrors[0].Validation)
-	assert.Equal(t, "/foo/bar", validationErrors[0].Path)
-	assert.EqualError(t, validationErrors[0].Error, "error decoding given PGP key: illegal base64 data at input byte 0")
-}
-
 func TestValidateValidateUsersSinglePathInValid(t *testing.T) {
 	// Todo add fixture for expired key
 	v := ValidateUser{}


### PR DESCRIPTION
Ever since introduction of account-notifier integration, pgp key validation is not required anymore. It could be re-introduced once early exit is implemented and we can diff if a new key was added. However it is safe to delete since account-notifier is supposed to handle invalid keys gracefully.

[APPSRE-4706](https://issues.redhat.com/browse/APPSRE-4706)