### PR TITLE
APPSRE-7614: Add retry for AppRole login when requesting new Vault client token

### DIFF
--- a/pkg/aws/credentials_test.go
+++ b/pkg/aws/credentials_test.go
@@ -70,6 +70,7 @@ func TestGetCredentialsFromVault(t *testing.T) {
 }
 
 func TestGuessAccountName(t *testing.T) {
+	t.Setenv("APP_INTERFACE_STATE_BUCKET_ACCOUNT", "")
 	assert.Equal(t, "", guessAccountName())
 
 	t.Setenv("APP_INTERFACE_STATE_BUCKET_ACCOUNT", "foo")

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+type retryError struct {
+	error
+}
+
+const (
+	// The factor by which to helve the jitter value.
+	jitterHelveFactor = 2
+
+	// The factor by which to increase the sleep time.
+	sleepStepFactor = 2
+)
+
+// Retry attempts to execute the given callback function a certain number of times,
+// with a delay between each attempt using a simple exponential backoff algorithm
+// that uses a slight jitter to ensure that retries aren't clustered.
+//
+// If the callback function returns an error, Retry will sleep for a certain duration
+// before attempting to call the callback function again.
+//
+// Retry will repeat this process until the callback function succeeds or until the
+// maximum number of attempts is reached.
+//
+// If the maximum number of attempts is reached and the callback function still fails,
+// it returns the last error returned by the callback function.
+func Retry(attempts int, sleep time.Duration, callbackFunc func() error) error {
+	var e retryError
+
+	if err := callbackFunc(); err != nil {
+		Log().Debugw("Retrying attempt", "attempts", attempts)
+		if errors.As(err, &e) {
+			return e.error
+		}
+		if attempts--; attempts > 0 {
+			sleep += jitter(sleep) / jitterHelveFactor
+			Log().Debugw("Sleeping before retrying", "sleep", sleep)
+			time.Sleep(sleep)
+			return Retry(attempts, sleepStepFactor*sleep, callbackFunc)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// RetryStop wraps the given error in a private retryError type and returns it to
+// signal that a retry loop should stop attempting the operation that produced the
+// given error.
+func RetryStop(err error) error {
+	return retryError{err}
+}
+
+// jitter returns a random duration that is less than the input duration to
+// introduce randomness into the duration that a retry loop sleeps between
+// retry attempts.
+func jitter(t time.Duration) time.Duration {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(t)))
+	if err != nil {
+		// Hopefully, this would never happen.
+		panic(fmt.Sprintf("unable to read random bytes: %s", err.Error()))
+	}
+	return time.Duration(n.Int64())
+}

--- a/pkg/util/retry_test.go
+++ b/pkg/util/retry_test.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		attempts    int
+		sleep       time.Duration
+		given       func(*int) func() error
+		expected    error
+	}{
+		{
+			"callback function returns no error",
+			1,
+			1 * time.Millisecond,
+			func(c *int) func() error {
+				return func() error {
+					*c++
+					return nil
+				}
+			},
+			nil,
+		},
+		{
+			"callback function returns an error",
+			1,
+			1 * time.Millisecond,
+			func(c *int) func() error {
+				return func() error {
+					*c++
+					return errors.New("test")
+				}
+			},
+			errors.New("test"),
+		},
+		{
+			"callback function returns an error to be retried five times",
+			5,
+			1 * time.Millisecond,
+			func(c *int) func() error {
+				return func() error {
+					*c++
+					return errors.New("test")
+				}
+			},
+			errors.New("test"),
+		},
+		{
+			"callback function returns no error using a custom error",
+			1,
+			1 * time.Millisecond,
+			func(c *int) func() error {
+				return func() error {
+					*c++
+					return RetryStop(nil)
+				}
+			},
+			nil,
+		},
+		{
+			"callback function requests to stop retrying with a custom error",
+			1,
+			1 * time.Millisecond,
+			func(c *int) func() error {
+				return func() error {
+					*c++
+					return RetryStop(errors.New("test-retry-stop"))
+				}
+			},
+			errors.New("test-retry-stop"),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			var attempts int
+			actual := Retry(tc.attempts, tc.sleep, tc.given(&attempts))
+
+			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tc.attempts, attempts)
+		})
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// How long before client requests to Vault are timed out.
+	defaultClientTimeout = 60 // Seconds.
+
 	// How long before a client login attempt to Vault is timed out.
 	defaultClientLoginTimeout = 5 * time.Second
 
@@ -53,7 +56,7 @@ type vaultConfig struct {
 func newVaultConfig() *vaultConfig {
 	var vc vaultConfig
 	sub := util.EnsureViperSub(viper.GetViper(), "vault")
-	sub.SetDefault("timeout", 60)
+	sub.SetDefault("timeout", defaultClientTimeout)
 	sub.SetDefault("authtype", "approle")
 	sub.SetDefault("kube_sa_token_path", "/var/run/secrets/kubernetes.io/serviceaccount/token")
 	sub.BindEnv("server", "VAULT_SERVER")

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -96,12 +96,12 @@ func NewVaultClient() (*Client, error) {
 		if err := approleAuthLogin(ctxTimeout, vaultClient); err != nil {
 			return nil, fmt.Errorf("unable to login with AppRole credentials: %w", err)
 		}
-	case "token":
-		vaultClient.client.SetToken(vc.Token)
 	case "kubernetes":
 		if err := kubernetesAuthLogin(ctxTimeout, vaultClient); err != nil {
 			return nil, fmt.Errorf("unable to login with Kubernetes credentials: %w", err)
 		}
+	case "token":
+		vaultClient.client.SetToken(vc.Token)
 	default:
 		return nil, fmt.Errorf("unsupported auth type \"%s\"", vc.AuthType)
 	}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -69,7 +69,7 @@ func newVaultConfig() *vaultConfig {
 	sub.BindEnv("kube_sa_token_path", "VAULT_KUBE_SA_TOKEN_PATH")
 	sub.BindEnv("timeout", "VAULT_TIMEOUT")
 	if err := sub.Unmarshal(&vc); err != nil {
-		util.Log().Fatalw("Error while unmarshalling configuration %s", err.Error())
+		util.Log().Fatalw("Error while unmarshalling configuration: %s", err.Error())
 	}
 	return &vc
 }
@@ -106,7 +106,7 @@ func NewVaultClient() (*Client, error) {
 	case "token":
 		vaultClient.client.SetToken(vc.Token)
 	default:
-		return nil, fmt.Errorf("unsupported auth type \"%s\"", vc.AuthType)
+		return nil, fmt.Errorf("unsupported authentication type %q", vc.AuthType)
 	}
 
 	return vaultClient, nil
@@ -136,7 +136,7 @@ func (v *Client) ListSecrets(secretPath string) (*SecretList, error) {
 			case string:
 				keyList = append(keyList, key)
 			default:
-				return nil, fmt.Errorf("unexpected return type for secret %s, this is a bug", secretPath)
+				return nil, fmt.Errorf("unexpected type for secret %q: %T", secretPath, key)
 			}
 		}
 	}

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -27,43 +27,43 @@ func setupViperAll() {
 	viper.GetViper().Set("vault", vaultCfg)
 }
 
-func setupViperEnv() {
-	os.Setenv("VAULT_TOKEN", "fooToken")
-	os.Setenv("VAULT_ROLE_ID", "fooRoleID")
-	os.Setenv("VAULT_SECRET_ID", "fooSecretID")
-	os.Setenv("VAULT_KUBE_AUTH_ROLE", "fooKubeRole")
-	os.Setenv("VAULT_KUBE_AUTH_MOUNT", "fooKubeMount")
-	os.Setenv("VAULT_KUBE_SA_TOKEN_PATH", "fooKubeTokenPath")
+func setupViperEnv(t *testing.T) {
+	t.Setenv("VAULT_TOKEN", "fooToken")
+	t.Setenv("VAULT_ROLE_ID", "fooRoleID")
+	t.Setenv("VAULT_SECRET_ID", "fooSecretID")
+	t.Setenv("VAULT_KUBE_AUTH_ROLE", "fooKubeRole")
+	t.Setenv("VAULT_KUBE_AUTH_MOUNT", "fooKubeMount")
+	t.Setenv("VAULT_KUBE_SA_TOKEN_PATH", "fooKubeTokenPath")
 
 	vaultCfg := make(map[string]interface{})
 	viper.GetViper().Set("vault", vaultCfg)
 }
 
-func setupViperToken() {
-	os.Setenv("VAULT_TOKEN", "token")
-	os.Setenv("VAULT_ADDR", "http://foo.example")
-	os.Setenv("VAULT_AUTHTYPE", "token")
+func setupViperToken(t *testing.T) {
+	t.Setenv("VAULT_TOKEN", "token")
+	t.Setenv("VAULT_ADDR", "http://foo.example")
+	t.Setenv("VAULT_AUTHTYPE", "token")
 
 	vaultCfg := make(map[string]interface{})
 	viper.GetViper().Set("vault", vaultCfg)
 }
 
-func setupViperAppRole() {
-	os.Setenv("VAULT_ROLE_ID", "bar")
-	os.Setenv("VAULT_SECRET_ID", "foo")
-	os.Setenv("VAULT_AUTHTYPE", "approle")
+func setupViperAppRole(t *testing.T) {
+	t.Setenv("VAULT_ROLE_ID", "bar")
+	t.Setenv("VAULT_SECRET_ID", "foo")
+	t.Setenv("VAULT_AUTHTYPE", "approle")
 
 	vaultCfg := make(map[string]interface{})
 	viper.GetViper().Set("vault", vaultCfg)
 }
 
-func setupViperKube() string {
-	os.Setenv("VAULT_AUTHTYPE", "kubernetes")
-	os.Setenv("VAULT_KUBE_AUTH_ROLE", "foo")
-	os.Setenv("VAULT_KUBE_AUTH_MOUNT", "kubernetes")
+func setupViperKube(t *testing.T) string {
+	t.Setenv("VAULT_AUTHTYPE", "kubernetes")
+	t.Setenv("VAULT_KUBE_AUTH_ROLE", "foo")
+	t.Setenv("VAULT_KUBE_AUTH_MOUNT", "kubernetes")
 
 	path := "./k8s-test-token"
-	os.Setenv("VAULT_KUBE_SA_TOKEN_PATH", path)
+	t.Setenv("VAULT_KUBE_SA_TOKEN_PATH", path)
 	os.WriteFile(path, []byte("base64jwt"), 0644)
 
 	vaultCfg := make(map[string]interface{})
@@ -87,7 +87,7 @@ func TestNewVaultConfigAll(t *testing.T) {
 }
 
 func TestNewVaultConfigEnv(t *testing.T) {
-	setupViperEnv()
+	setupViperEnv(t)
 	vc := newVaultConfig()
 
 	assert.Equal(t, vc.Token, "fooToken")
@@ -99,7 +99,7 @@ func TestNewVaultConfigEnv(t *testing.T) {
 }
 
 func TestNewVaultClientToken(t *testing.T) {
-	setupViperToken()
+	setupViperToken(t)
 	v, err := NewVaultClient()
 
 	assert.Nil(t, err)
@@ -107,7 +107,7 @@ func TestNewVaultClientToken(t *testing.T) {
 }
 
 func TestNewVaultClientAppRole(t *testing.T) {
-	setupViperAppRole()
+	setupViperAppRole(t)
 	mockedToken := "65b74ffd-842c-fd43-1386-f7d7006e520a"
 	vaultMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "auth/approle/login")
@@ -116,11 +116,10 @@ func TestNewVaultClientAppRole(t *testing.T) {
 		assert.Equal(t, `{"role_id":"bar","secret_id":"foo"}`, string(sentBody))
 
 		fmt.Fprintf(w, `{"auth": {"client_token": "%s"}}`, mockedToken)
-
 	}))
 	defer vaultMock.Close()
 
-	os.Setenv("VAULT_SERVER", vaultMock.URL)
+	t.Setenv("VAULT_SERVER", vaultMock.URL)
 
 	v, err := NewVaultClient()
 	assert.Nil(t, err)
@@ -129,7 +128,7 @@ func TestNewVaultClientAppRole(t *testing.T) {
 }
 
 func TestNewVaultClientKube(t *testing.T) {
-	path := setupViperKube()
+	path := setupViperKube(t)
 	defer os.Remove(path)
 
 	mockedToken := "65b74ffd-842c-fd43-1386-f7d7006e520a"
@@ -143,7 +142,7 @@ func TestNewVaultClientKube(t *testing.T) {
 	}))
 	defer vaultMock.Close()
 
-	os.Setenv("VAULT_SERVER", vaultMock.URL)
+	t.Setenv("VAULT_SERVER", vaultMock.URL)
 
 	v, err := NewVaultClient()
 	assert.Nil(t, err)
@@ -152,7 +151,7 @@ func TestNewVaultClientKube(t *testing.T) {
 }
 
 func TestNewVaultClientUnsuportedAuthType(t *testing.T) {
-	os.Setenv("VAULT_AUTHTYPE", "jkjisdf")
+	t.Setenv("VAULT_AUTHTYPE", "jkjisdf")
 
 	_, err := NewVaultClient()
 	assert.NotNil(t, err)
@@ -164,9 +163,9 @@ func TestVaultClientTimeout(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(2 * time.Second)
 		}))
-	setupViperToken()
-	os.Setenv("VAULT_SERVER", vaultMock.URL)
-	os.Setenv("VAULT_TIMEOUT", "1")
+	setupViperToken(t)
+	t.Setenv("VAULT_SERVER", vaultMock.URL)
+	t.Setenv("VAULT_TIMEOUT", "1")
 
 	client, err := NewVaultClient()
 	assert.NotNil(t, client)

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -156,7 +156,7 @@ func TestNewVaultClientUnsuportedAuthType(t *testing.T) {
 
 	_, err := NewVaultClient()
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "unsupported auth type \"jkjisdf\"")
+	assert.EqualError(t, err, "unsupported authentication type \"jkjisdf\"")
 }
 
 func TestVaultClientTimeout(t *testing.T) {


### PR DESCRIPTION
Currently, we authenticate with Vault using the Role and Secret IDs and write to the AppRole mount endpoint to "login" to obtain a new client token. However, this request might return an empty response without failing, resulting in `secret.Auth` to be nil due to missing authentication information causing a nil pointer dereference error.

As such, we need to ensure that this request to retrieve the client token, should it fail or return no data, is more robust and can be a type of failure that is handled gracefully.

Thus, this change adds support to ensure that failed authentication requests are retried to address potential transient failures such as timeouts and missing authentication information, etc.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>