### PR TITLE
User Validator use comparison sha

### DIFF
--- a/internal/uservalidator/user_validator.go
+++ b/internal/uservalidator/user_validator.go
@@ -207,12 +207,10 @@ func findUsersToValidate(users *UsersResponse, compareUsers *UsersResponse) []Us
 	for _, user := range users.GetUsers_v1() {
 		userMap[user.GetPath()] = user
 	}
-	fmt.Println(userMap)
 	compareUserMap := make(map[string]UsersUsers_v1User_v1)
 	for _, user := range compareUsers.GetUsers_v1() {
 		compareUserMap[user.GetPath()] = user
 	}
-	fmt.Println(compareUserMap)
 
 	var usersToValidate = make([]UsersUsers_v1User_v1, 0)
 

--- a/pkg/gql/qontract_client.go
+++ b/pkg/gql/qontract_client.go
@@ -85,7 +85,6 @@ func NewQontractClient(ctx context.Context) (*QontractClient, error) {
 		config: config,
 	}
 
-	fmt.Println(config.CompareSha)
 	if len(config.CompareSha) > 0 {
 		path := fmt.Sprintf("/graphqlsha/%s", config.CompareSha)
 		compareClient := graphql.NewClient(strings.ReplaceAll(config.Server, "/graphql", path), retryClient)

--- a/pkg/gql/qontract_client.go
+++ b/pkg/gql/qontract_client.go
@@ -27,19 +27,26 @@ var _ = `# @genqlient
     }
 }`
 
+type useCompareClient string
+
+// UseCompareClientKey is the key used to store the useCompareClient value in the context
+var UseCompareClientKey useCompareClient = "useCompareClient"
+
 // QontractClient abstraction for generated GraphQL client
 //
 //go:generate go run github.com/Khan/genqlient
 type QontractClient struct {
-	Client graphql.Client
-	config *qontractConfig
+	Client        graphql.Client
+	CompareClinet *graphql.Client
+	config        *qontractConfig
 }
 
 type qontractConfig struct {
-	Server  string
-	Timeout int
-	Token   string
-	Retries int
+	Server     string
+	Timeout    int
+	Token      string
+	Retries    int
+	CompareSha string
 }
 
 func newQontractConfig() *qontractConfig {
@@ -47,10 +54,12 @@ func newQontractConfig() *qontractConfig {
 	sub := util.EnsureViperSub(viper.GetViper(), "graphql")
 	sub.SetDefault("timeout", 60)
 	sub.SetDefault("retries", 5)
+	sub.SetDefault("CompareSha", "")
 	sub.BindEnv("server", "GRAPHQL_SERVER")
 	sub.BindEnv("timeout", "GRAPHQL_TIMEOUT")
 	sub.BindEnv("token", "GRAPHQL_TOKEN")
 	sub.BindEnv("retries", "GRAPHQL_RETRIES")
+	sub.BindEnv("comparesha", "COMPARE_SHA")
 	if err := sub.Unmarshal(&qc); err != nil {
 		util.Log().Fatalw("Error while unmarshalling configuration %s", err.Error())
 	}
@@ -75,6 +84,14 @@ func NewQontractClient(ctx context.Context) (*QontractClient, error) {
 		Client: graphql.NewClient(config.Server, retryClient),
 		config: config,
 	}
+
+	fmt.Println(config.CompareSha)
+	if len(config.CompareSha) > 0 {
+		path := fmt.Sprintf("/graphqlsha/%s", config.CompareSha)
+		compareClient := graphql.NewClient(strings.ReplaceAll(config.Server, "/graphql", path), retryClient)
+		client.CompareClinet = &compareClient
+	}
+
 	return client, nil
 }
 
@@ -100,7 +117,17 @@ func (c *QontractClient) ensureSchema(integrationName string, resp *graphql.Resp
 
 // MakeRequest makes a request to graphql server, ensuring schema usage is allowed
 func (c *QontractClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
-	err := c.Client.MakeRequest(ctx, req, resp)
+	var client graphql.Client
+	useCompare := ctx.Value(UseCompareClientKey)
+	if useCompare != nil && useCompare.(bool) == true {
+		client = *c.CompareClinet
+		if client == nil {
+			return fmt.Errorf("compare client not initialized")
+		}
+	} else {
+		client = c.Client
+	}
+	err := client.MakeRequest(ctx, req, resp)
 	if err != nil {
 		return err
 	}

--- a/pkg/unleash/unleash.go
+++ b/pkg/unleash/unleash.go
@@ -55,7 +55,7 @@ func NewUnleashClient() (*Client, error) {
 		Client: &http.Client{
 			Timeout: time.Duration(c.Timeout) * time.Second,
 			Transport: &util.AuthedTransport{
-				Key:     fmt.Sprintf("Bearer %s", c.ClientAccessToken),
+				Key:     c.ClientAccessToken,
 				Wrapped: http.DefaultTransport,
 			},
 		},

--- a/pkg/unleash/unleash_test.go
+++ b/pkg/unleash/unleash_test.go
@@ -2,7 +2,6 @@ package unleash
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -36,7 +35,7 @@ func TestGetFeature(t *testing.T) {
 	ctx := context.Background()
 	mock := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, fmt.Sprintf("Bearer %s", token), r.Header.Get("Authorization"))
+			assert.Equal(t, token, r.Header.Get("Authorization"))
 			assert.Equal(t, r.URL.Path, "/client/features/test")
 			w.Write([]byte(`{"enabled":true,"name":"test","project":"default","type":"release"}`))
 		}))


### PR DESCRIPTION
This changes user-validator to only verify changed users. This enables adding gpg key validation back. Make spotting these issues easier

Additionally, this fixes the unleash implementation, removing the `Bearer` prefix.

Related:

- [APPSRE-7691](https://issues.redhat.com/browse/APPSRE-7691)
- [APPSRE-7703](https://issues.redhat.com/browse/APPSRE-7703)