### PR TITLE
vault read fallback on kv v2

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -114,7 +114,17 @@ func NewVaultClient() (*Client, error) {
 
 // ReadSecret do a logical read on a given Secret Path
 func (v *Client) ReadSecret(secretPath string) (*api.Secret, error) {
-	return v.client.Logical().Read(secretPath)
+	// return v.client.Logical().Read(secretPath)
+	// Attempt to read the secret as KV v1
+	secret, err := v.client.Logical().Read(secretPath)
+	if err == nil && secret != nil {
+		return secret, nil
+	}
+
+	// Fallback to KV v2 by modifying the path to include the "data/" prefix
+	parts := strings.SplitN(secretPath, "/", 2)
+	kv2Path := fmt.Sprintf("%s/data/%s", parts[0], parts[1])
+	return v.client.Logical().Read(kv2Path)
 }
 
 // SecretList is a list of secrets


### PR DESCRIPTION
integration is failing when facing a kv v2 secret engine with the following error:
```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/app-sre/go-qontract-reconcile/pkg/aws.getCredentialsFromVault(0x14a8be8?, 0xc000137590?)
	/build/pkg/aws/credentials.go:41 +0x205
github.com/app-sre/go-qontract-reconcile/pkg/aws.GetAwsCredentials({0x14a8be8, 0xc000137590}, 0xc000310750)
	/build/pkg/aws/credentials.go:69 +0xa5
github.com/app-sre/go-qontract-reconcile/internal/accountnotifier.(*AccountNotifier).Setup(0xc0001156c0, {0x14a8be8, 0xc000137590})
	/build/internal/accountnotifier/account_notifier.go:393 +0x85
github.com/app-sre/go-qontract-reconcile/pkg/reconcile.(*IntegrationRunner).runIntegration(0xc000133380)
	/build/pkg/reconcile/integration.go:122 +0x12e
github.com/app-sre/go-qontract-reconcile/pkg/reconcile.(*IntegrationRunner).Run(0xc000133380)
	/build/pkg/reconcile/integration.go:162 +0x90
github.com/app-sre/go-qontract-reconcile/cmd.accountNotifier()
	/build/cmd/account_notifier.go:11 +0x35
github.com/app-sre/go-qontract-reconcile/cmd.init.func2(0xc000142300?, {0x12ee8cf?, 0x4?, 0x12ee8d3?})
	/build/cmd/root.go:40 +0xf
github.com/spf13/cobra.(*Command).execute(0x1ce0660, {0xc000123c40, 0x2, 0x2})
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x1ce00a0)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/app-sre/go-qontract-reconcile/cmd.Execute(...)
	/build/cmd/root.go:65
main.main()
	/build/main.go:7 +0x1b
```