### PR TITLE
APPSRE-12249(fix): delete orphaned s3 refs when configs removed from app-interface

### DIFF
--- a/internal/gitpartitionsync/producer/producer.go
+++ b/internal/gitpartitionsync/producer/producer.go
@@ -202,7 +202,7 @@ func (g *GitPartitionSyncProducer) DesiredState(ctx context.Context, ri *reconci
 }
 
 func needsUpdate(current *currentState, desired *s3ObjectInfo) bool {
-	if current != nil {
+	if current != nil && desired != nil {
 		for _, s3ObjectInfo := range current.S3ObjectInfos {
 			// Current commit (from desired) is already in S3, thus exit
 			if s3ObjectInfo.CommitSHA == desired.CommitSHA {

--- a/internal/gitpartitionsync/producer/producer.go
+++ b/internal/gitpartitionsync/producer/producer.go
@@ -309,7 +309,7 @@ func (g *GitPartitionSyncProducer) LogDiff(ri *reconcile.ResourceInventory) {
 			desired = state.Desired.(*s3ObjectInfo)
 		}
 		// log orphaned objects - objects that exist in S3 but not in app-interface
-		if state.Config == nil && state.Desired == nil && state.Current != nil {
+		if state.Config == nil && state.Desired == nil && current != nil {
 			util.Log().Infof("Orphaned project %s will have %d S3 object(s) deleted", target, len(current.S3ObjectInfos))
 			continue
 		}


### PR DESCRIPTION
PR consists of code changes to `git-partition-sync-producer`.  If `gitlabSync` for a code component is removed from app-interface corresponding s3 entries will also be removed.